### PR TITLE
Implement extend, alloc_uninit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typed-arena"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 description = "The arena, a fast but limited type of allocator"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,14 @@ impl<T> Arena<T> {
         }
     }
 
+    /// Allocates a value in the arena, and returns a mutable reference
+    /// to that value.
     pub fn alloc(&self, value: T) -> &mut T {
         &mut self.alloc_extend(iter::once(value))[0]
     }
 
+    /// Uses the contents of an iterator to allocate values in the arena.
+    /// Returns a mutable slice that contains these values.
     pub fn alloc_extend<I>(&self, iter: I) -> &mut [T]
         where I: Iterator<Item = T> + ExactSizeIterator
     {
@@ -86,6 +90,7 @@ impl<T> Arena<T> {
         new_slice_ref
     }
 
+    /// Allocates space for a given number of values, but doesn't initialize it.
     pub unsafe fn alloc_uninitialized(&self, num: usize) -> *mut [T] {
         let mut chunks = self.chunks.borrow_mut();
 
@@ -100,6 +105,7 @@ impl<T> Arena<T> {
         &mut chunks.current[next_item_index..] as *mut _
     }
 
+    /// Returns unused space.
     pub fn uninitialized_array(&self) -> *mut [T] {
         let chunks = self.chunks.borrow();
         let len = chunks.current.capacity() - chunks.current.len();

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,7 +21,7 @@ fn arena_as_intended() {
         assert_eq!(arena.chunks.borrow().rest.len(), 0);
 
         node = arena.alloc(Node(Some(node), 2, DropTracker(&drop_counter)));
-        assert_eq!(arena.chunks.borrow().rest.len(), 1);
+        assert_eq!(arena.chunks.borrow().rest.len(), 0);
 
         node = arena.alloc(Node(Some(node), 3, DropTracker(&drop_counter)));
         assert_eq!(arena.chunks.borrow().rest.len(), 1);
@@ -33,7 +33,7 @@ fn arena_as_intended() {
         assert_eq!(node.0.unwrap().1, 3);
         assert_eq!(node.0.unwrap().0.unwrap().1, 2);
         assert_eq!(node.0.unwrap().0.unwrap().0.unwrap().1, 1);
-        assert   !(node.0.unwrap().0.unwrap().0.unwrap().0.is_none());
+        assert!(node.0.unwrap().0.unwrap().0.unwrap().0.is_none());
 
         mem::drop(node);
         assert_eq!(drop_counter.get(), 0);
@@ -42,7 +42,7 @@ fn arena_as_intended() {
         assert_eq!(arena.chunks.borrow().rest.len(), 1);
 
         node = arena.alloc(Node(Some(node), 6, DropTracker(&drop_counter)));
-        assert_eq!(arena.chunks.borrow().rest.len(), 2);
+        assert_eq!(arena.chunks.borrow().rest.len(), 1);
 
         node = arena.alloc(Node(Some(node), 7, DropTracker(&drop_counter)));
         assert_eq!(arena.chunks.borrow().rest.len(), 2);
@@ -52,7 +52,7 @@ fn arena_as_intended() {
         assert_eq!(node.1, 7);
         assert_eq!(node.0.unwrap().1, 6);
         assert_eq!(node.0.unwrap().0.unwrap().1, 5);
-        assert   !(node.0.unwrap().0.unwrap().0.is_none());
+        assert!(node.0.unwrap().0.unwrap().0.is_none());
 
         assert_eq!(drop_counter.get(), 0);
 


### PR DESCRIPTION
These methods allow allocation of contiguous memory (slices).