### PR TITLE
Added docs.rs badge, documentation link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.2.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 description = "The arena, a fast but limited type of allocator"
+documentation = "https://docs.rs/typed-arena"
 repository = "https://github.com/SimonSapin/rust-typed-arena"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 rust-typed-arena
 ================
 
+[![Docs Status](https://docs.rs/typed-arena/badge.svg)](https://docs.rs/typed-arena)
+
 The arena, a fast but limited type of allocator.
 
 Arenas are a type of allocator that destroy the objects within,


### PR DESCRIPTION
It was bugging me that every time I visited the repository, I went to look at the source to figure out how to use it. I eventually realized that docs.rs has automagically built the documentation for this crate; here is a PR to add the docs.rs badge, linking to the docs.rs documentation, as well as a "Documentation" link in the cargo.toml which should show up on crates.io.