### PR TITLE
Support no_std by gating std usage on a "std" feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,13 @@ license = "MIT"
 description = "The arena, a fast but limited type of allocator"
 documentation = "https://docs.rs/typed-arena"
 repository = "https://github.com/SimonSapin/rust-typed-arena"
-categories = ["memory-management"]
+categories = ["memory-management", "no-std"]
 
 [lib]
 name = "typed_arena"
 path = "src/lib.rs"
 doctest = false
+
+[features]
+default = ["std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,23 @@
 // 2) add and stabilize placement new.
 // 3) use an iterator. This may add far too much unsafe code.
 
-use std::cell::RefCell;
-use std::cmp;
-use std::iter;
-use std::mem;
-use std::slice;
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(any(feature = "std", test))]
+extern crate core;
+
+#[cfg(not(feature = "std"))]
+use alloc::Vec;
+
+use core::cell::RefCell;
+use core::cmp;
+use core::iter;
+use core::mem;
+use core::slice;
 
 #[cfg(test)]
 mod test;
@@ -51,7 +63,7 @@ impl<T> Arena<T> {
         Arena {
             chunks: RefCell::new(ChunkList {
                 current: Vec::with_capacity(n),
-                rest: vec![],
+                rest: Vec::new(),
             }),
         }
     }


### PR DESCRIPTION
This adds an enabled-by-default `"std"` cargo feature which can be selectively removed to enable `no_std` support.

When the "std" feature is absent, `feature(collections)` will be enabled to provide `Vec` support. This requires nightly, but since "std" is enabled by default, this should have no impact on stable users.