### PR TITLE
no_std + checking no_std builds in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,9 @@ rust:
   - nightly
   - beta
   - stable
+
+script:
+  - cargo test
+  - if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
+      cargo build --no-default-features;
+    fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,13 @@ license = "MIT"
 description = "The arena, a fast but limited type of allocator"
 documentation = "https://docs.rs/typed-arena"
 repository = "https://github.com/SimonSapin/rust-typed-arena"
-categories = ["memory-management"]
+categories = ["memory-management", "no-std"]
 
 [lib]
 name = "typed_arena"
 path = "src/lib.rs"
 doctest = false
+
+[features]
+default = ["std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,23 @@
 // 2) add and stabilize placement new.
 // 3) use an iterator. This may add far too much unsafe code.
 
-use std::cell::RefCell;
-use std::cmp;
-use std::iter;
-use std::mem;
-use std::slice;
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(any(feature = "std", test))]
+extern crate core;
+
+#[cfg(not(feature = "std"))]
+use alloc::Vec;
+
+use core::cell::RefCell;
+use core::cmp;
+use core::iter;
+use core::mem;
+use core::slice;
 
 #[cfg(test)]
 mod test;
@@ -51,7 +63,7 @@ impl<T> Arena<T> {
         Arena {
             chunks: RefCell::new(ChunkList {
                 current: Vec::with_capacity(n),
-                rest: vec![],
+                rest: Vec::new(),
             }),
         }
     }


### PR DESCRIPTION
Was going to rebase #10 to use `feature(alloc)` rather than `feature(collections)` but it was already done. Added a check that no_std builds in Travis CI while I was at it.

r? @SimonSapin 