### PR TITLE
Implement default trait for arena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Released YYYY/MM/DD.
 
 ### Added
 
-* TODO (or remove section if none)
+* Implement `Default` for `Arena<T>`.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,12 @@ impl<T> Arena<T> {
     }
 }
 
+impl<T> Default for Arena<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> ChunkList<T> {
     #[inline(never)]
     #[cold]


### PR DESCRIPTION
Implement `Default::default` for `Arena<T>` as an alias for `new()`. This allows the arena to be embedded into structs with `#[derive(Default)]`.