### PR TITLE
fix for Miri and add Miri to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 sudo: false
 language: rust
-rust:
-  - nightly
-  - beta
-  - stable
+
+matrix:
+    include:
+    - rust: stable
+    - rust: beta
+    - rust: nightly
+
+    - rust: nightly
+      os: linux
+      env: DESCRIPTION="Miri"
+      script:
+        - sh ci/miri.sh
 
 script:
   - cargo test

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,0 +1,10 @@
+set -ex
+
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
+rustup default "$MIRI_NIGHTLY"
+
+rustup component add miri
+cargo miri setup
+
+cargo miri test


### PR DESCRIPTION
This fixes running the fast path allocation function in Miri. The issue with the old function is that it implicitly calls `Vec::deref_mut`, which creates a mutable slice covering all elements of the vector -- so if there are other pointers into that vector, they are now invalid, because the slice must be a unique pointer. The fix is to avoid `Vec::deref_mut`.

This is an instance of https://github.com/rust-lang/unsafe-code-guidelines/issues/133: the mutable reference (for the slice) is created but never used, and still Stacked Borrows requires it to be unique. See that issue for further details.

This also sets up CI to run Miri. I hope I got that right.