### PR TITLE
pin a working version of Miri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: rust
 
 matrix:
-  allow_failures:
-    - name: "Miri"
   include:
     - rust: stable
     - rust: beta

--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,6 +1,7 @@
 set -ex
 
-MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+#MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
+MIRI_NIGHTLY=nightly-2019-09-11
 echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
 rustup default "$MIRI_NIGHTLY"
 


### PR DESCRIPTION
Instead of disabling Miri, pin a version that should work.