### PR TITLE
Fix rustc version regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: rust
 
 matrix:
   include:
+    - rust: 1.32.0
     - rust: stable
     - rust: beta
     - rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,7 +445,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<&'a mut T> {
         loop {
-            match self.state {
+            self.state = match self.state {
                 IterMutState::ChunkListRest {
                     mut index,
                     ref mut inner_iter,
@@ -458,20 +458,18 @@ impl<'a, T> Iterator for IterMut<'a, T> {
                                 let inner_iter = self.chunks.rest[index].iter_mut();
                                 // Extend the lifetime of the individual elements to that of the arena.
                                 let inner_iter = unsafe { mem::transmute(inner_iter) };
-                                self.state = IterMutState::ChunkListRest { index, inner_iter };
-                                continue;
+                                IterMutState::ChunkListRest { index, inner_iter }
                             } else {
                                 let iter = self.chunks.current.iter_mut();
                                 // Extend the lifetime of the individual elements to that of the arena.
                                 let iter = unsafe { mem::transmute(iter) };
-                                self.state = IterMutState::ChunkListCurrent { iter };
-                                continue;
+                                IterMutState::ChunkListCurrent { iter }
                             }
                         }
                     }
                 }
                 IterMutState::ChunkListCurrent { ref mut iter } => return iter.next(),
-            }
+            };
         }
     }
 


### PR DESCRIPTION
This commit:

- Pins the rustc version to 1.32.0
- Rearranges the mutable iterator logic to pass older versions of the borrow checker (pre-1.36)

Fixes #31