### PR TITLE
go back to using nightly Miri

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -1,7 +1,6 @@
 set -ex
 
-#MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
-MIRI_NIGHTLY=nightly-2019-09-11
+MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
 echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
 rustup default "$MIRI_NIGHTLY"
 


### PR DESCRIPTION
Nightly Miri has worked fine throughout October; I think we can go back to using the latest version on CI. Also https://github.com/rust-lang/rust/pull/66053 will hopefully soon fix the underlying issue that caused the problem the last time.