### PR TITLE
Arena::<u8>::alloc_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Released YYYY/MM/DD.
 
 ### Added
 
-* TODO (or remove section if none)
+* Added `alloc_str` to `Arena<u8>`, to be able to allocate string slices.
 
 ### Changed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use core::cmp;
 use core::iter;
 use core::mem;
 use core::slice;
+use core::str;
 
 #[cfg(test)]
 mod test;
@@ -424,6 +425,29 @@ impl<T> Arena<T> {
             chunks,
             state: position,
         }
+    }
+}
+
+impl Arena<u8> {
+    /// Allocates a string slice and returns a mutable reference to it.
+    ///
+    /// This is on `Arena<u8>`, because string slices use byte slices (`[u8]`) as their backing
+    /// storage.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use typed_arena::Arena;
+    ///
+    /// let arena: Arena<u8> = Arena::new();
+    /// let hello = arena.alloc_str("Hello world");
+    /// assert_eq!("Hello world", hello);
+    /// ```
+    #[inline]
+    pub fn alloc_str(&self, s: &str) -> &mut str {
+        let buffer = self.alloc_extend(s.bytes());
+        // Can't fail the utf8 validation, it already came in as utf8
+        unsafe { str::from_utf8_unchecked_mut(buffer) }
     }
 }
 


### PR DESCRIPTION
For allocating string slices. This is similar to allocating normal
slices, but needs a special method as they are a bit strange (with
variable-length characters).

Closes #37.

Is it enough to have just the doc-test for it? I don't think a non-doc test would add any further coverage.