### PR TITLE
Support #![no_std] on stable Rust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,4 @@ matrix:
 
 script:
   - cargo test
-  - if [[ "$TRAVIS_RUST_VERSION" == "nightly" ]]; then
-      cargo build --no-default-features;
-    fi
+  - cargo build --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Released YYYY/MM/DD.
 
 ### Fixed
 
+* Support `#![no_std]` on stable Rust.
 * TODO (or remove section if none)
 
 ### Security

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,6 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;


### PR DESCRIPTION
`alloc` is stable on Rust 1.36.0 which is the minimum supported version.