### PR TITLE
Fix inconsistency of docs with events played out in DBZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ struct Monster {
 
 let monsters = Arena::new();
 
-let vegeta = monsters.alloc(Monster { level: 9001 });
-assert!(vegeta.level > 9000);
+let goku = monsters.alloc(Monster { level: 9001 });
+assert!(goku.level > 9000);
 ```
 
 ## Safe Cycles

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! let monsters = Arena::new();
 //!
-//! let vegeta = monsters.alloc(Monster { level: 9001 });
-//! assert!(vegeta.level > 9000);
+//! let goku = monsters.alloc(Monster { level: 9001 });
+//! assert!(goku.level > 9000);
 //! ```
 //!
 //! ## Safe Cycles


### PR DESCRIPTION
It was, in fact, Goku, whose power level was over 9000.