### PR TITLE
Use `ptr::slice_from_raw_parts` to fix UB in Miri

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,10 +400,10 @@ impl<T> Arena<T> {
         let next_item_index = chunks.current.len();
 
         unsafe {
-        // Go through pointers, to make sure we never create a reference to uninitialized T.
+            // Go through pointers, to make sure we never create a reference to uninitialized T.
             let start = chunks.current.as_mut_ptr().offset(next_item_index as isize);
             let start_uninit = start as *mut MaybeUninit<T>;
-            slice::from_raw_parts_mut(start_uninit, len) as *mut _
+            std::ptr::slice_from_raw_parts_mut(start_uninit, len)
         }
     }
 


### PR DESCRIPTION
Closes #52 by using `ptr::slice_from_raw_parts` instead of creating a raw slice and casting to a pointer