### PR TITLE
Miri fixes (various)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.41.0
+      - uses: dtolnay/rust-toolchain@1.42.0
       # Can't run tests because we have ed2021 crates in the dev-dependency
       # graph, which old cargo can't parse. It seems likely that tests would
       # pass on older versions if the crate builds and they pass on stable,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.36.0
+      - uses: dtolnay/rust-toolchain@1.41.0
       # Can't run tests because we have ed2021 crates in the dev-dependency
       # graph, which old cargo can't parse. It seems likely that tests would
       # pass on older versions if the crate builds and they pass on stable,
@@ -89,13 +89,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo doc --all-features
 
-  # FIXME (currently fails)
-  # miri:
-  #   name: Miri
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: dtolnay/rust-toolchain@nightly
-  #       with:
-  #         components: miri, rust-src
-  #     - run: cargo miri test --all-features
+  miri:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri, rust-src
+      - run: cargo miri test --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,14 +264,16 @@ impl<T> Arena<T> {
                 i += 1;
             }
         }
-        let new_slice_ref = &mut chunks.current[next_item_index..];
 
         // Extend the lifetime from that of `chunks_borrow` to that of `self`.
         // This is OK because we’re careful to never move items
         // by never pushing to inner `Vec`s beyond their initial capacity.
         // The returned reference is unique (`&mut`):
         // the `Arena` never gives away references to existing items.
-        unsafe { mem::transmute::<&mut [T], &mut [T]>(new_slice_ref) }
+        unsafe {
+            let new_len = chunks.current.len() - next_item_index;
+            slice::from_raw_parts_mut(chunks.current.as_mut_ptr().add(next_item_index), new_len)
+        }
     }
 
     /// Allocates space for a given number of values, but doesn't initialize it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ use core::cell::RefCell;
 use core::cmp;
 use core::iter;
 use core::mem;
+use core::ptr;
 use core::slice;
 use core::str;
 
@@ -403,7 +404,7 @@ impl<T> Arena<T> {
             // Go through pointers, to make sure we never create a reference to uninitialized T.
             let start = chunks.current.as_mut_ptr().offset(next_item_index as isize);
             let start_uninit = start as *mut MaybeUninit<T>;
-            slice::from_raw_parts_mut(start_uninit, len) as *mut _
+            ptr::slice_from_raw_parts_mut(start_uninit, len)
         }
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -322,12 +322,11 @@ fn size_hint() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn size_hint_low_initial_capacities() {
     #[derive(Debug, PartialEq, Eq)]
     struct NonCopy(usize);
 
-    const MAX: usize = 25_000;
+    const MAX: usize = if cfg!(miri) { 100 } else { 25_000 };
     const CAP: usize = 0;
 
     for cap in CAP..(CAP + 128/* check some non-power-of-two capacities */) {
@@ -341,12 +340,11 @@ fn size_hint_low_initial_capacities() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn size_hint_high_initial_capacities() {
     #[derive(Debug, PartialEq, Eq)]
     struct NonCopy(usize);
 
-    const MAX: usize = 25_000;
+    const MAX: usize = if cfg!(miri) { 100 } else { 25_000 };
     const CAP: usize = 8164;
 
     for cap in CAP..(CAP + 128/* check some non-power-of-two capacities */) {
@@ -360,12 +358,11 @@ fn size_hint_high_initial_capacities() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn size_hint_many_items() {
     #[derive(Debug, PartialEq, Eq)]
     struct NonCopy(usize);
 
-    const MAX: usize = 5_000_000;
+    const MAX: usize = if cfg!(miri) { 500 } else { 5_000_000 };
     const CAP: usize = 16;
 
     let mut arena = Arena::with_capacity(CAP);

--- a/src/test.rs
+++ b/src/test.rs
@@ -321,6 +321,17 @@ fn size_hint() {
     }
 }
 
+// Ensure that `alloc_extend` doesn't violate provenance of
+// existing references. (Note: This test is pointless except
+// under miri).
+#[test]
+fn check_extend_provenance() {
+    let arena = Arena::new();
+    let a = arena.alloc(0);
+    arena.alloc_extend([0]);
+    *a = 1;
+}
+
 #[test]
 fn size_hint_low_initial_capacities() {
     #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
This incorporates the changes from #54 and #55 (thanks @clubby789 and @human-0 for those fixes!), but with some changes that aren't worth waiting on review back and forth.

It also re-enables miri in CI, and removes `#[cfg_attr(miri, ignore)]` from some tests.

This required bumping MSRV to 1.42 which is still very old, so I don't think it matters realistically.