### PR TITLE
Prep release 2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "typed-arena"
-version = "2.0.1"
-authors = ["Simon Sapin <simon.sapin@exyr.org>", "Nick Fitzgerald <fitzgen@gmail.com>"]
+version = "2.0.2"
+authors = ["The typed-arena developers"]
 license = "MIT"
 description = "The arena, a fast but limited type of allocator"
 documentation = "https://docs.rs/typed-arena"


### PR DESCRIPTION
This also changes the `authors` field to `["The typed-arena developers"]` which matches the copyright notice in the [LICENSE](https://github.com/SimonSapin/rust-typed-arena/blob/master/LICENSE#L3) file.