### PR TITLE
Move benches into own workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - win32
           - beta
           - nightly
+          - msrv
         include:
           - name: linux
             os: ubuntu-latest
@@ -49,6 +50,9 @@ jobs:
           - name: nightly
             os: ubuntu-latest
             toolchain: nightly
+          - name: msrv
+            os: ubuntu-latest
+            toolchain: '1.42.0'
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -57,17 +61,6 @@ jobs:
       - run: cargo check --verbose
       - run: cargo test --verbose
       - run: cargo build --no-default-features
-  MSRV:
-    name: Check MSRV
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@1.42.0
-      # Can't run tests because we have ed2021 crates in the dev-dependency
-      # graph, which old cargo can't parse. It seems likely that tests would
-      # pass on older versions if the crate builds and they pass on stable,
-      # though.
-      - run: cargo build --verbose
 
   # Check formatting
   rustfmt:
@@ -79,6 +72,8 @@ jobs:
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
+        working-directory: ./benches
 
   # linkcheck docs (we have `-Dwarnings` in RUSTFLAGS and RUSTDOCFLAGS above)
   doc:
@@ -98,3 +93,30 @@ jobs:
         with:
           components: miri, rust-src
       - run: cargo miri test --all-features
+
+  benches:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      # Use a cache for this both because the builds are slow, and because it
+      # allows criterion to take a (very low quality) guess about perf changes.
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            benches/target
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-benches-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-benches-${{ hashFiles('**/Cargo.toml') }}
+            ${{ runner.os }}-benches-
+            ${{ runner.os }}-
+      - name: Build benchmarks
+        run: cargo bench --no-run
+        working-directory: ./benches
+      - name: Run benchmarks
+        run: cargo bench
+        working-directory: ./benches

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    // Benchmarks are in a separate workspace for reasons documented in
+    // `benchmarks/README.md`, so `rust-analyzer` needs some help finding it.
+    "rust-analyzer.linkedProjects": ["Cargo.toml", "benchmarks/Cargo.toml"]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ repository = "https://github.com/SimonSapin/rust-typed-arena"
 categories = ["memory-management", "no-std"]
 keywords = ["arena"]
 readme = "./README.md"
+exclude = ["benchmarks"]
+autobenches = false
 
 [lib]
 name = "typed_arena"
@@ -18,13 +20,5 @@ path = "src/lib.rs"
 default = ["std"]
 std = []
 
-[dev-dependencies]
-criterion = "0.3.4"
-
-[[bench]]
-name = "benches"
-path = "benches/benches.rs"
-harness = false
-
-[profile.bench]
-debug = true
+[workspace]
+exclude = ["benches"]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "typed-arena-benchmarks"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+criterion = "0.4.0"
+typed-arena = { path = ".." }
+
+[[bench]]
+name = "benches"
+path = "benches.rs"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,12 @@
+# `typed-arena-benchmarks`
+
+## Why is this a separate workspace?
+
+This is in a separate workspace to avoid issues with having criterion as a
+dev-dependency. Specifically:
+
+1. Criterion and its transitive dependencies have a much higher MSRV. Specifically, high enough that cargo fails to parse their manifest toml when building, so we can't even build anything that requires dev-dependencies, such as tests.
+
+2. Criterion is slow to build. Having it as a dev-dependency means we need to build it in order to run tests. Some of the CI runners are very slow, and this dominates their time. It also slows down local builds for little benefit.
+
+In exchange, the repository setup is slightly weirder, and so users may not realize there are two things to check.

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,7 +1,3 @@
-#[macro_use]
-extern crate criterion;
-extern crate typed_arena;
-
 use criterion::{BenchmarkId, Criterion};
 
 #[derive(Default)]
@@ -32,5 +28,5 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);
+criterion::criterion_group!(benches, criterion_benchmark);
+criterion::criterion_main!(benches);

--- a/src/test.rs
+++ b/src/test.rs
@@ -328,7 +328,7 @@ fn size_hint() {
 fn check_extend_provenance() {
     let arena = Arena::new();
     let a = arena.alloc(0);
-    arena.alloc_extend([0]);
+    arena.alloc_extend(core::iter::once(1));
     *a = 1;
 }
 
@@ -336,8 +336,10 @@ fn check_extend_provenance() {
 fn size_hint_low_initial_capacities() {
     #[derive(Debug, PartialEq, Eq)]
     struct NonCopy(usize);
-
-    const MAX: usize = if cfg!(miri) { 100 } else { 25_000 };
+    #[cfg(miri)]
+    const MAX: usize = 100;
+    #[cfg(not(miri))]
+    const MAX: usize = 25_000;
     const CAP: usize = 0;
 
     for cap in CAP..(CAP + 128/* check some non-power-of-two capacities */) {
@@ -355,7 +357,10 @@ fn size_hint_high_initial_capacities() {
     #[derive(Debug, PartialEq, Eq)]
     struct NonCopy(usize);
 
-    const MAX: usize = if cfg!(miri) { 100 } else { 25_000 };
+    #[cfg(miri)]
+    const MAX: usize = 100;
+    #[cfg(not(miri))]
+    const MAX: usize = 25_000;
     const CAP: usize = 8164;
 
     for cap in CAP..(CAP + 128/* check some non-power-of-two capacities */) {
@@ -373,7 +378,10 @@ fn size_hint_many_items() {
     #[derive(Debug, PartialEq, Eq)]
     struct NonCopy(usize);
 
-    const MAX: usize = if cfg!(miri) { 500 } else { 5_000_000 };
+    #[cfg(miri)]
+    const MAX: usize = 500;
+    #[cfg(not(miri))]
+    const MAX: usize = 5_000_000;
     const CAP: usize = 16;
 
     let mut arena = Arena::with_capacity(CAP);


### PR DESCRIPTION
This also re-adds MSRV testing to CI. It also adds the benchmarks themselves into CI, which may or may not be worth it. (It will probably become less worth it as I add more benchmarks...).

Doing this isn't unheard of, although it's a bit weird. It has various benefits (as documented in `benches/README.md`. One downside that I've taken care to mitigate is that rust-analyzer doesn't detect cases like this automatically (unlike CLion, which does). To mitigate that downside, I've added a `.vscode/settings.json` to the repository that will configure the VSCode-based rust-analyzer users automatically (and perhaps point the others towards the right settings to use)?

Anyway, I'm planning on adding more benchmarks soon, to justify some optimizations I'm hoping to make, but this was bothering me.