### PR TITLE
Fixes no_std by removing accidental dependence on std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "typed-arena"
-version = "2.0.1"
+name = "typed-arena-nomut"
+version = "0.1.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>", "Nick Fitzgerald <fitzgen@gmail.com>"]
 license = "MIT"
 description = "The arena, a fast but limited type of allocator"
 documentation = "https://docs.rs/typed-arena"
-repository = "https://github.com/SimonSapin/rust-typed-arena"
+repository = "https://github.com/jrmuizel/typed-arena-nomut"
 categories = ["memory-management", "no-std"]
 keywords = ["arena"]
 readme = "./README.md"
 
 [lib]
-name = "typed_arena"
+name = "typed_arena_nomut"
 path = "src/lib.rs"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# `typed-arena`
+# `typed-arena-nomut`
 
-[![](https://docs.rs/typed-arena/badge.svg)](https://docs.rs/typed-arena/)
-[![](https://img.shields.io/crates/v/typed-arena.svg)](https://crates.io/crates/typed-arena)
-[![](https://img.shields.io/crates/d/typed-arena.svg)](https://crates.io/crates/typed-arena)
-[![Travis CI Build Status](https://travis-ci.org/SimonSapin/rust-typed-arena.svg?branch=master)](https://travis-ci.org/SimonSapin/typed-arena)
+[![](https://docs.rs/typed-arena-nomut/badge.svg)](https://docs.rs/typed-arena-nomut/)
+[![](https://img.shields.io/crates/v/typed-arena-nomut.svg)](https://crates.io/crates/typed-arena-nomut)
+[![](https://img.shields.io/crates/d/typed-arena-nomut.svg)](https://crates.io/crates/typed-arena-nomut)
+
+This is a fork of the typed-arena arena crate that returns an immutable reference instead of
+mutable one. This allows iteration on the arena items while they're borrowed.
 
 **A fast (but limited) allocation arena for values of a single type.**
 
@@ -14,10 +16,11 @@ alive. The flipside is that allocation is fast: typically just a vector push.
 There is also a method `into_vec()` to recover ownership of allocated objects
 when the arena is no longer required, instead of destroying everything.
 
+
 ## Example
 
 ```rust
-use typed_arena::Arena;
+use typed_arena_nomut::Arena;
 
 struct Monster {
     level: u32,
@@ -37,7 +40,7 @@ and trees with parent pointers.
 
 ```rust
 use std::cell::Cell;
-use typed_arena::Arena;
+use typed_arena_nomut::Arena;
 
 struct CycleParticipant<'a> {
     other: Cell<Option<&'a CycleParticipant<'a>>>,

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate criterion;
-extern crate typed_arena;
+extern crate typed_arena_nomut;
 
 use criterion::{Criterion, BenchmarkId};
 
@@ -11,9 +11,9 @@ struct Small(usize);
 struct Big([usize; 32]);
 
 fn allocate<T: Default>(n: usize) {
-    let arena = typed_arena::Arena::new();
+    let arena = typed_arena_nomut::Arena::new();
     for _ in 0..n {
-        let val: &mut T = arena.alloc(Default::default());
+        let val: &T = arena.alloc(Default::default());
         criterion::black_box(val);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use core::iter;
 use core::mem;
 use core::slice;
 use core::str;
-use std::cell::Ref;
+use core::cell::Ref;
 
 use mem::MaybeUninit;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -240,7 +240,7 @@ fn iter_mut_low_capacity() {
     const MAX: usize = 1_000;
     const CAP: usize = 16;
 
-    let mut arena = Arena::with_capacity(CAP);
+    let arena = Arena::with_capacity(CAP);
     for i in 1..MAX {
         arena.alloc(NonCopy(i));
     }
@@ -250,9 +250,9 @@ fn iter_mut_low_capacity() {
         "expected multiple chunks"
     );
 
-    let mut iter = arena.iter_mut();
+    let mut iter = arena.iter();
     for i in 1..MAX {
-        assert_eq!(Some(&mut NonCopy(i)), iter.next());
+        assert_eq!(Some(&NonCopy(i)), iter.next());
     }
 
     assert_eq!(None, iter.next());
@@ -266,7 +266,7 @@ fn iter_mut_high_capacity() {
     const MAX: usize = 1_000;
     const CAP: usize = 8192;
 
-    let mut arena = Arena::with_capacity(CAP);
+    let arena = Arena::with_capacity(CAP);
     for i in 1..MAX {
         arena.alloc(NonCopy(i));
     }
@@ -276,15 +276,15 @@ fn iter_mut_high_capacity() {
         "expected single chunk"
     );
 
-    let mut iter = arena.iter_mut();
+    let mut iter = arena.iter();
     for i in 1..MAX {
-        assert_eq!(Some(&mut NonCopy(i)), iter.next());
+        assert_eq!(Some(&NonCopy(i)), iter.next());
     }
 
     assert_eq!(None, iter.next());
 }
 
-fn assert_size_hint<T>(arena_len: usize, iter: IterMut<'_, T>) {
+fn assert_size_hint<T>(arena_len: usize, iter: Iter<'_, T>) {
     let (min, max) = iter.size_hint();
 
     assert!(max.is_some());
@@ -308,10 +308,10 @@ fn size_hint() {
     const CAP: usize = 0;
 
     for cap in CAP..(CAP + 16/* check some non-power-of-two capacities */) {
-        let mut arena = Arena::with_capacity(cap);
+        let arena = Arena::with_capacity(cap);
         for i in 1..MAX {
             arena.alloc(NonCopy(i));
-            let iter = arena.iter_mut();
+            let iter = arena.iter();
             assert_size_hint(i, iter);
         }
     }
@@ -327,10 +327,10 @@ fn size_hint_low_initial_capacities() {
     const CAP: usize = 0;
 
     for cap in CAP..(CAP + 128/* check some non-power-of-two capacities */) {
-        let mut arena = Arena::with_capacity(cap);
+        let arena = Arena::with_capacity(cap);
         for i in 1..MAX {
             arena.alloc(NonCopy(i));
-            let iter = arena.iter_mut();
+            let iter = arena.iter();
             assert_size_hint(i, iter);
         }
     }
@@ -346,10 +346,10 @@ fn size_hint_high_initial_capacities() {
     const CAP: usize = 8164;
 
     for cap in CAP..(CAP + 128/* check some non-power-of-two capacities */) {
-        let mut arena = Arena::with_capacity(cap);
+        let arena = Arena::with_capacity(cap);
         for i in 1..MAX {
             arena.alloc(NonCopy(i));
-            let iter = arena.iter_mut();
+            let iter = arena.iter();
             assert_size_hint(i, iter);
         }
     }
@@ -364,10 +364,10 @@ fn size_hint_many_items() {
     const MAX: usize = 5_000_000;
     const CAP: usize = 16;
 
-    let mut arena = Arena::with_capacity(CAP);
+    let arena = Arena::with_capacity(CAP);
     for i in 1..MAX {
         arena.alloc(NonCopy(i));
-        let iter = arena.iter_mut();
+        let iter = arena.iter();
         assert_size_hint(i, iter);
     }
 }


### PR DESCRIPTION
The current code accidentally imports std::cell::Ref, which causes the code to fail to compile when the `std` feature is deactivated. I replaced this import with an import of core::cell::Ref, which accomplishes the same purpose while remaining compatible with no_std.